### PR TITLE
feat: Spoolman-compatible API and Klipper integration

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,100 @@
+name: Staging Deploy (Beta)
+
+on:
+  push:
+    branches: [beta]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: beta
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Publish
+        run: |
+          dotnet publish src/SpoolManager.Server/SpoolManager.Server.csproj \
+            -c Release \
+            -o ./publish \
+            --no-self-contained
+
+      - name: Create archive
+        run: cd publish && zip -r ../spoolhero-beta.zip .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spoolhero-beta
+          path: spoolhero-beta.zip
+          retention-days: 3
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: spoolhero-beta
+
+      - name: Stop service
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: systemctl stop spoolhero-beta || true
+
+      - name: Upload archive
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "spoolhero-beta.zip"
+          target: "/tmp/"
+
+      - name: Deploy and start
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            rm -rf /opt/spoolhero-beta
+            mkdir -p /opt/spoolhero-beta
+            unzip /tmp/spoolhero-beta.zip -d /opt/spoolhero-beta
+            rm /tmp/spoolhero-beta.zip
+            cp /opt/appsettings-beta.json /opt/spoolhero-beta/appsettings.json
+            chown -R www-data:www-data /opt/spoolhero-beta
+
+            # Create systemd service if it doesn't exist yet
+            if [ ! -f /etc/systemd/system/spoolhero-beta.service ]; then
+              cat > /etc/systemd/system/spoolhero-beta.service << 'EOF'
+            [Unit]
+            Description=SpoolHero Beta Staging
+            After=network.target
+
+            [Service]
+            WorkingDirectory=/opt/spoolhero-beta
+            ExecStart=/usr/bin/dotnet /opt/spoolhero-beta/SpoolManager.Server.dll
+            Restart=always
+            RestartSec=5
+            User=www-data
+            Environment=ASPNETCORE_ENVIRONMENT=Staging
+            Environment=ASPNETCORE_URLS=http://localhost:5100
+
+            [Install]
+            WantedBy=multi-user.target
+            EOF
+              systemctl daemon-reload
+              systemctl enable spoolhero-beta
+            fi
+
+            systemctl start spoolhero-beta

--- a/src/SpoolManager.Client/Layout/MainLayout.razor
+++ b/src/SpoolManager.Client/Layout/MainLayout.razor
@@ -135,6 +135,7 @@ else
                             <li><a class="dropdown-item" href="/settings/account"><i class="bi bi-person-gear me-2"></i>@L["nav.settings.account"]</a></li>
                             <li><a class="dropdown-item" href="/settings/password"><i class="bi bi-key me-2"></i>@L["auth.change.password"]</a></li>
                             <li><a class="dropdown-item" href="/settings/notifications"><i class="bi bi-bell me-2"></i>@L["settings.notifications.title"]</a></li>
+                            <li><a class="dropdown-item" href="/settings/spoolman"><i class="bi bi-plug me-2"></i>@L["nav.settings.spoolman"]</a></li>
                             <li><hr class="dropdown-divider"></li>
                             <li>
                                 <button class="dropdown-item text-danger" @onclick="LogoutAsync">
@@ -252,6 +253,11 @@ else
                 <li class="nav-item mt-1">
                     <a class="btn btn-outline-secondary w-100" href="/settings/notifications" @onclick="CloseOffcanvas">
                         <i class="bi bi-bell me-2"></i>@L["settings.notifications.title"]
+                    </a>
+                </li>
+                <li class="nav-item mt-1">
+                    <a class="btn btn-outline-secondary w-100" href="/settings/spoolman" @onclick="CloseOffcanvas">
+                        <i class="bi bi-plug me-2"></i>@L["nav.settings.spoolman"]
                     </a>
                 </li>
                 <li class="nav-item mt-2">

--- a/src/SpoolManager.Client/Pages/Settings/SpoolmanSettings.razor
+++ b/src/SpoolManager.Client/Pages/Settings/SpoolmanSettings.razor
@@ -1,0 +1,132 @@
+@page "/settings/spoolman"
+@inject SpoolmanApiKeyService ApiKeys
+@inject LocalizationService L
+@inject IJSRuntime JS
+
+<PageTitle>@L["spoolman.title"] – @L["app.name"]</PageTitle>
+
+<div class="page-header">
+    <h1><i class="bi bi-plug me-2"></i>@L["spoolman.title"]</h1>
+</div>
+
+<div class="alert alert-info small mb-4">
+    <i class="bi bi-info-circle me-1"></i>@L["spoolman.hint"]
+    <pre class="mb-0 mt-2 p-2 bg-white border rounded" style="font-size:0.75rem">[spoolman]
+server: https://your-spoolhero-url.com
+sync_rate: 5</pre>
+</div>
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span class="fw-semibold"><i class="bi bi-key me-1"></i>@L["spoolman.apikeys"]</span>
+        <button class="btn btn-sm btn-primary" @onclick="() => _showCreate = true" disabled="@_showCreate">
+            <i class="bi bi-plus-lg me-1"></i>@L["spoolman.apikeys.create"]
+        </button>
+    </div>
+    <div class="card-body">
+        @if (_showCreate)
+        {
+            <div class="row g-2 mb-3 align-items-end">
+                <div class="col">
+                    <label class="form-label form-label-sm">@L["spoolman.apikeys.name"]</label>
+                    <input class="form-control form-control-sm" @bind="_newKeyName" placeholder="e.g. Moonraker" />
+                </div>
+                <div class="col-auto d-flex gap-1">
+                    <button class="btn btn-sm btn-success" @onclick="CreateKeyAsync" disabled="@(string.IsNullOrWhiteSpace(_newKeyName) || _creating)">
+                        @if (_creating) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                        @L["common.save"]
+                    </button>
+                    <button class="btn btn-sm btn-secondary" @onclick="() => { _showCreate = false; _newKeyName = string.Empty; }">
+                        @L["common.cancel"]
+                    </button>
+                </div>
+            </div>
+        }
+
+        @if (_loading)
+        {
+            <div class="text-center py-3"><div class="spinner-border spinner-border-sm"></div></div>
+        }
+        else if (_keys == null || _keys.Count == 0)
+        {
+            <p class="text-muted mb-0">@L["spoolman.apikeys.empty"]</p>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>@L["spoolman.apikeys.name"]</th>
+                            <th>API Key</th>
+                            <th>@L["common.created"]</th>
+                            <th>@L["spoolman.apikeys.lastused"]</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var key in _keys)
+                        {
+                            <tr>
+                                <td>@key.Name</td>
+                                <td>
+                                    <code class="small user-select-all">@key.ApiKey</code>
+                                    <button class="btn btn-sm btn-link p-0 ms-1" title="@L["common.copy"]" @onclick="() => CopyToClipboard(key.ApiKey)">
+                                        <i class="bi bi-clipboard"></i>
+                                    </button>
+                                </td>
+                                <td class="small text-muted">@key.CreatedAt.ToLocalTime().ToString("g")</td>
+                                <td class="small text-muted">@(key.LastUsedAt?.ToLocalTime().ToString("g") ?? "–")</td>
+                                <td class="text-end">
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteKeyAsync(key.Id)">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    private List<SpoolmanApiKeyDto>? _keys;
+    private bool _loading = true;
+    private bool _showCreate;
+    private string _newKeyName = string.Empty;
+    private bool _creating;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _keys = await ApiKeys.GetAllAsync();
+        _loading = false;
+    }
+
+    private async Task CreateKeyAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_newKeyName)) return;
+        _creating = true;
+        var created = await ApiKeys.CreateAsync(_newKeyName.Trim());
+        if (created != null)
+        {
+            _keys ??= new();
+            _keys.Insert(0, created);
+        }
+        _newKeyName = string.Empty;
+        _showCreate = false;
+        _creating = false;
+    }
+
+    private async Task DeleteKeyAsync(Guid id)
+    {
+        await ApiKeys.DeleteAsync(id);
+        _keys?.RemoveAll(k => k.Id == id);
+    }
+
+    private async Task CopyToClipboard(string text)
+    {
+        try { await JS.InvokeAsync<bool>("clipboardHelper.copy", text); } catch { }
+    }
+}

--- a/src/SpoolManager.Client/Pages/Spools/SpoolDetail.razor
+++ b/src/SpoolManager.Client/Pages/Spools/SpoolDetail.razor
@@ -148,6 +148,13 @@ else
                 <div class="card-body">
                     <h6 class="card-subtitle mb-3 text-muted">Details</h6>
                     <div class="row g-2">
+                        @if (_spool.SpoolmanId > 0)
+                        {
+                            <div class="col-6 col-md-3">
+                                <small class="text-muted d-block">@L["spoolman.id"]</small>
+                                <span class="badge bg-secondary">@_spool.SpoolmanId</span>
+                            </div>
+                        }
                         <div class="col-6 col-md-3">
                             <small class="text-muted d-block">@L["spool.printer"]</small>
                             @(_spool.PrinterName ?? "–")

--- a/src/SpoolManager.Client/Program.cs
+++ b/src/SpoolManager.Client/Program.cs
@@ -27,5 +27,6 @@ builder.Services.AddScoped<AdminService>();
 builder.Services.AddScoped<TicketService>();
 builder.Services.AddScoped<SettingsService>();
 builder.Services.AddScoped<BrandingService>();
+builder.Services.AddScoped<SpoolmanApiKeyService>();
 
 await builder.Build().RunAsync();

--- a/src/SpoolManager.Client/Services/SpoolmanApiKeyService.cs
+++ b/src/SpoolManager.Client/Services/SpoolmanApiKeyService.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Json;
+using SpoolManager.Shared.DTOs.Spoolman;
+
+namespace SpoolManager.Client.Services;
+
+public class SpoolmanApiKeyService
+{
+    private readonly HttpClient _http;
+    public SpoolmanApiKeyService(HttpClient http) => _http = http;
+
+    public Task<List<SpoolmanApiKeyDto>?> GetAllAsync() =>
+        _http.GetFromJsonAsync<List<SpoolmanApiKeyDto>>("api/spoolman/apikeys");
+
+    public async Task<SpoolmanApiKeyDto?> CreateAsync(string name)
+    {
+        var resp = await _http.PostAsJsonAsync("api/spoolman/apikeys", new CreateSpoolmanApiKeyRequest { Name = name });
+        if (!resp.IsSuccessStatusCode) return null;
+        return await resp.Content.ReadFromJsonAsync<SpoolmanApiKeyDto>();
+    }
+
+    public Task<HttpResponseMessage> DeleteAsync(Guid id) =>
+        _http.DeleteAsync($"api/spoolman/apikeys/{id}");
+}

--- a/src/SpoolManager.Client/_Imports.razor
+++ b/src/SpoolManager.Client/_Imports.razor
@@ -20,3 +20,4 @@
 @using SpoolManager.Shared.DTOs.Dryers
 @using SpoolManager.Shared.DTOs.Admin
 @using SpoolManager.Shared.DTOs.Tickets
+@using SpoolManager.Shared.DTOs.Spoolman

--- a/src/SpoolManager.Client/wwwroot/i18n/de.json
+++ b/src/SpoolManager.Client/wwwroot/i18n/de.json
@@ -452,5 +452,15 @@
 
   "auth.terms.accept": "Ich akzeptiere die",
   "auth.privacy.accept": "Ich habe die",
-  "auth.terms.required": "Bitte akzeptiere die Nutzungsbedingungen und die Datenschutzerklärung."
+  "auth.terms.required": "Bitte akzeptiere die Nutzungsbedingungen und die Datenschutzerklärung.",
+
+  "spoolman.title": "Klipper / Spoolman Integration",
+  "spoolman.hint": "SpoolHero stellt eine Spoolman-kompatible API bereit. Füge folgendes in deine moonraker.conf ein, um automatisches Filament-Tracking zu aktivieren:",
+  "spoolman.apikeys": "API-Schlüssel",
+  "spoolman.apikeys.create": "API-Schlüssel erstellen",
+  "spoolman.apikeys.name": "Name",
+  "spoolman.apikeys.lastused": "Zuletzt benutzt",
+  "spoolman.apikeys.empty": "Noch keine API-Schlüssel. Erstelle einen, um Moonraker zu verbinden.",
+  "spoolman.id": "Spoolman-ID",
+  "nav.settings.spoolman": "Klipper-Integration"
 }

--- a/src/SpoolManager.Client/wwwroot/i18n/en.json
+++ b/src/SpoolManager.Client/wwwroot/i18n/en.json
@@ -452,5 +452,15 @@
 
   "auth.terms.accept": "I accept the",
   "auth.privacy.accept": "I have read and agree to the",
-  "auth.terms.required": "Please accept the Terms of Use and Privacy Policy."
+  "auth.terms.required": "Please accept the Terms of Use and Privacy Policy.",
+
+  "spoolman.title": "Klipper / Spoolman Integration",
+  "spoolman.hint": "SpoolHero provides a Spoolman-compatible API. Add the following to your moonraker.conf to enable automatic filament tracking:",
+  "spoolman.apikeys": "API Keys",
+  "spoolman.apikeys.create": "Create API Key",
+  "spoolman.apikeys.name": "Name",
+  "spoolman.apikeys.lastused": "Last Used",
+  "spoolman.apikeys.empty": "No API keys yet. Create one to connect Moonraker.",
+  "spoolman.id": "Spoolman ID",
+  "nav.settings.spoolman": "Klipper Integration"
 }

--- a/src/SpoolManager.Infrastructure/Data/Mappings/SpoolManagerMappings.cs
+++ b/src/SpoolManager.Infrastructure/Data/Mappings/SpoolManagerMappings.cs
@@ -139,6 +139,7 @@ public static class SpoolManagerMappings
             .HasTableName("spools")
             .HasPrimaryKey(x => x.Id)
             .Property(x => x.Id).HasColumnName("id")
+            .Property(x => x.SpoolmanId).HasColumnName("spoolman_id")
             .Property(x => x.ProjectId).HasColumnName("project_id")
             .Property(x => x.FilamentMaterialId).HasColumnName("filament_material_id")
             .Property(x => x.RfidTagUid).HasColumnName("rfid_tag_uid")
@@ -227,6 +228,16 @@ public static class SpoolManagerMappings
             .Property(x => x.FromName).HasColumnName("from_name")
             .Property(x => x.IsEnabled).HasColumnName("is_enabled")
             .Property(x => x.BaseUrl).HasColumnName("base_url");
+
+        builder.Entity<SpoolmanApiKey>()
+            .HasTableName("spoolman_api_keys")
+            .HasPrimaryKey(x => x.Id)
+            .Property(x => x.Id).HasColumnName("id")
+            .Property(x => x.ProjectId).HasColumnName("project_id")
+            .Property(x => x.ApiKey).HasColumnName("api_key")
+            .Property(x => x.Name).HasColumnName("name")
+            .Property(x => x.CreatedAt).HasColumnName("created_at")
+            .Property(x => x.LastUsedAt).HasColumnName("last_used_at");
 
         builder.Build();
         return schema;

--- a/src/SpoolManager.Infrastructure/Data/SpoolManagerDb.cs
+++ b/src/SpoolManager.Infrastructure/Data/SpoolManagerDb.cs
@@ -22,4 +22,5 @@ public class SpoolManagerDb : DataConnection
     public ITable<TicketComment> TicketComments => this.GetTable<TicketComment>();
     public ITable<SmtpSettings> SmtpSettings => this.GetTable<SmtpSettings>();
     public ITable<SiteSetting> SiteSettings => this.GetTable<SiteSetting>();
+    public ITable<SpoolmanApiKey> SpoolmanApiKeys => this.GetTable<SpoolmanApiKey>();
 }

--- a/src/SpoolManager.Infrastructure/Migrations/M011_SpoolmanCompat.cs
+++ b/src/SpoolManager.Infrastructure/Migrations/M011_SpoolmanCompat.cs
@@ -1,0 +1,26 @@
+using FluentMigrator;
+
+namespace SpoolManager.Infrastructure.Migrations;
+
+[Migration(11)]
+public class M011_SpoolmanCompat : Migration
+{
+    public override void Up()
+    {
+        Execute.Sql("ALTER TABLE spools ADD COLUMN spoolman_id INT NOT NULL AUTO_INCREMENT UNIQUE");
+
+        Create.Table("spoolman_api_keys")
+            .WithColumn("id").AsString(36).PrimaryKey()
+            .WithColumn("project_id").AsString(36).NotNullable().ForeignKey("projects", "id").OnDelete(System.Data.Rule.Cascade)
+            .WithColumn("api_key").AsString(64).NotNullable().Unique()
+            .WithColumn("name").AsString(100).NotNullable()
+            .WithColumn("created_at").AsDateTime().NotNullable()
+            .WithColumn("last_used_at").AsDateTime().Nullable();
+    }
+
+    public override void Down()
+    {
+        Delete.Table("spoolman_api_keys");
+        Execute.Sql("ALTER TABLE spools DROP COLUMN spoolman_id");
+    }
+}

--- a/src/SpoolManager.Infrastructure/Repositories/SpoolRepository.cs
+++ b/src/SpoolManager.Infrastructure/Repositories/SpoolRepository.cs
@@ -14,6 +14,9 @@ public interface ISpoolRepository
     Task DeleteAsync(Guid id);
     Task<int> GetTotalCountAsync();
     Task<List<Spool>> GetSpoolsNeedingLowNotificationAsync();
+    Task<Spool?> GetBySpoolmanIdAsync(int spoolmanId, Guid projectId);
+    Task<List<Spool>> GetAllByProjectAsync(Guid projectId);
+    Task UpdateRemainingWeightAtomicAsync(Guid spoolId, decimal subtractGrams, decimal totalWeightGrams);
 }
 
 public class SpoolRepository : ISpoolRepository
@@ -130,6 +133,37 @@ public class SpoolRepository : ISpoolRepository
 
     public async Task<int> GetTotalCountAsync() =>
         await _db.Spools.CountAsync();
+
+    public async Task<Spool?> GetBySpoolmanIdAsync(int spoolmanId, Guid projectId)
+    {
+        var spool = await _db.Spools.FirstOrDefaultAsync(s => s.SpoolmanId == spoolmanId && s.ProjectId == projectId);
+        return await LoadNavPropsAsync(spool);
+    }
+
+    public async Task<List<Spool>> GetAllByProjectAsync(Guid projectId)
+    {
+        var spools = await _db.Spools
+            .Where(s => s.ProjectId == projectId)
+            .OrderByDescending(s => s.CreatedAt)
+            .ToListAsync();
+
+        foreach (var spool in spools)
+            spool.FilamentMaterial = await _db.FilamentMaterials.FirstOrDefaultAsync(m => m.Id == spool.FilamentMaterialId);
+
+        return spools;
+    }
+
+    public async Task UpdateRemainingWeightAtomicAsync(Guid spoolId, decimal subtractGrams, decimal totalWeightGrams)
+    {
+        await _db.Spools
+            .Where(s => s.Id == spoolId)
+            .Set(s => s.RemainingWeightGrams, s => s.RemainingWeightGrams - subtractGrams < 0 ? 0 : s.RemainingWeightGrams - subtractGrams)
+            .Set(s => s.RemainingPercent, s => totalWeightGrams > 0
+                ? (s.RemainingWeightGrams - subtractGrams < 0 ? 0 : (s.RemainingWeightGrams - subtractGrams) / totalWeightGrams * 100)
+                : 0)
+            .Set(s => s.UpdatedAt, DateTime.UtcNow)
+            .UpdateAsync();
+    }
 
     public async Task<List<Spool>> GetSpoolsNeedingLowNotificationAsync()
     {

--- a/src/SpoolManager.Infrastructure/Repositories/SpoolmanApiKeyRepository.cs
+++ b/src/SpoolManager.Infrastructure/Repositories/SpoolmanApiKeyRepository.cs
@@ -1,0 +1,47 @@
+using LinqToDB;
+using SpoolManager.Infrastructure.Data;
+using SpoolManager.Shared.Models;
+
+namespace SpoolManager.Infrastructure.Repositories;
+
+public interface ISpoolmanApiKeyRepository
+{
+    Task<SpoolmanApiKey?> GetByApiKeyAsync(string apiKey);
+    Task<List<SpoolmanApiKey>> GetAllByProjectAsync(Guid projectId);
+    Task<Guid> CreateAsync(SpoolmanApiKey key);
+    Task DeleteAsync(Guid id);
+    Task UpdateLastUsedAsync(Guid id);
+}
+
+public class SpoolmanApiKeyRepository : ISpoolmanApiKeyRepository
+{
+    private readonly SpoolManagerDb _db;
+
+    public SpoolmanApiKeyRepository(SpoolManagerDb db) => _db = db;
+
+    public async Task<SpoolmanApiKey?> GetByApiKeyAsync(string apiKey) =>
+        await _db.SpoolmanApiKeys.FirstOrDefaultAsync(k => k.ApiKey == apiKey);
+
+    public async Task<List<SpoolmanApiKey>> GetAllByProjectAsync(Guid projectId) =>
+        await _db.SpoolmanApiKeys
+            .Where(k => k.ProjectId == projectId)
+            .OrderByDescending(k => k.CreatedAt)
+            .ToListAsync();
+
+    public async Task<Guid> CreateAsync(SpoolmanApiKey key)
+    {
+        key.Id = Guid.NewGuid();
+        key.CreatedAt = DateTime.UtcNow;
+        await _db.InsertAsync(key);
+        return key.Id;
+    }
+
+    public async Task DeleteAsync(Guid id) =>
+        await _db.SpoolmanApiKeys.Where(k => k.Id == id).DeleteAsync();
+
+    public async Task UpdateLastUsedAsync(Guid id) =>
+        await _db.SpoolmanApiKeys
+            .Where(k => k.Id == id)
+            .Set(k => k.LastUsedAt, DateTime.UtcNow)
+            .UpdateAsync();
+}

--- a/src/SpoolManager.Infrastructure/Services/OpenSpoolService.cs
+++ b/src/SpoolManager.Infrastructure/Services/OpenSpoolService.cs
@@ -7,7 +7,7 @@ namespace SpoolManager.Infrastructure.Services;
 
 public interface IOpenSpoolService
 {
-    byte[] Encode(FilamentMaterial material, Guid? spoolId = null);
+    byte[] Encode(FilamentMaterial material, Guid? spoolId = null, int? spoolmanId = null);
     byte[] EncodeEntityTag(string entityType, Guid entityId);
     (FilamentMaterial material, bool isValid) Decode(byte[] ndefBytes);
     string ToJson(FilamentMaterial material, Guid? spoolId = null);
@@ -107,12 +107,39 @@ public class OpenSpoolService : IOpenSpoolService
         }
     }
 
-    public byte[] Encode(FilamentMaterial material, Guid? spoolId = null)
+    public byte[] Encode(FilamentMaterial material, Guid? spoolId = null, int? spoolmanId = null)
     {
         var json = ToJson(material, spoolId);
         var jsonBytes = Encoding.UTF8.GetBytes(json);
         var typeBytes = Encoding.UTF8.GetBytes("application/json");
-        return BuildNdefMessage(typeBytes, jsonBytes);
+        var openSpoolRecord = BuildNdefRecord(typeBytes, jsonBytes, isFirst: spoolmanId == null, isLast: spoolmanId == null);
+
+        if (spoolmanId.HasValue)
+        {
+            var spoolmanText = $"SPOOL:{spoolmanId.Value}";
+            var spoolmanBytes = Encoding.UTF8.GetBytes(spoolmanText);
+            var textType = Encoding.UTF8.GetBytes("T");
+            var firstRecord = BuildNdefRecord(typeBytes, jsonBytes, isFirst: true, isLast: false);
+            var lastRecord = BuildNdefRecord(textType, BuildTextPayload(spoolmanText), isFirst: false, isLast: true, tnf: 0x01);
+
+            using var ms = new MemoryStream();
+            ms.Write(firstRecord, 0, firstRecord.Length);
+            ms.Write(lastRecord, 0, lastRecord.Length);
+            return ms.ToArray();
+        }
+
+        return openSpoolRecord;
+    }
+
+    private static byte[] BuildTextPayload(string text)
+    {
+        var textBytes = Encoding.UTF8.GetBytes(text);
+        var langCode = Encoding.ASCII.GetBytes("en");
+        var payload = new byte[1 + langCode.Length + textBytes.Length];
+        payload[0] = (byte)langCode.Length;
+        Array.Copy(langCode, 0, payload, 1, langCode.Length);
+        Array.Copy(textBytes, 0, payload, 1 + langCode.Length, textBytes.Length);
+        return payload;
     }
 
     public byte[] EncodeEntityTag(string entityType, Guid entityId)
@@ -142,10 +169,18 @@ public class OpenSpoolService : IOpenSpoolService
 
     private static byte[] BuildNdefMessage(byte[] typeBytes, byte[] payload)
     {
+        return BuildNdefRecord(typeBytes, payload, isFirst: true, isLast: true);
+    }
+
+    private static byte[] BuildNdefRecord(byte[] typeBytes, byte[] payload, bool isFirst, bool isLast, byte tnf = 0x02)
+    {
         var typeLength = (byte)typeBytes.Length;
         bool isShortRecord = payload.Length <= 255;
 
-        var flags = (byte)(0xD0 | (isShortRecord ? 0x10 : 0x00) | 0x02);
+        byte flags = tnf;
+        if (isFirst) flags |= 0x80;
+        if (isLast) flags |= 0x40;
+        if (isShortRecord) flags |= 0x10;
 
         using var ms = new MemoryStream();
         ms.WriteByte(flags);

--- a/src/SpoolManager.Server/Controllers/SpoolmanController.cs
+++ b/src/SpoolManager.Server/Controllers/SpoolmanController.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Mvc;
+using SpoolManager.Infrastructure.Repositories;
+using SpoolManager.Server.Filters;
+using SpoolManager.Shared.DTOs.Spoolman;
+using SpoolManager.Shared.Models;
+
+namespace SpoolManager.Server.Controllers;
+
+[ApiController]
+[Route("api/v1")]
+public class SpoolmanController : ControllerBase
+{
+    private readonly ISpoolRepository _spools;
+
+    public SpoolmanController(ISpoolRepository spools)
+    {
+        _spools = spools;
+    }
+
+    private Guid ProjectId => (Guid)HttpContext.Items["SpoolmanProjectId"]!;
+
+    [HttpGet("health")]
+    public IActionResult Health() => Ok(new SpoolmanHealthResponse());
+
+    [HttpGet("info")]
+    public IActionResult Info() => Ok(new SpoolmanInfoResponse());
+
+    [HttpGet("spool/{id:int}")]
+    [ServiceFilter(typeof(SpoolmanAuthFilter))]
+    public async Task<IActionResult> GetSpool(int id)
+    {
+        var spool = await _spools.GetBySpoolmanIdAsync(id, ProjectId);
+        if (spool == null) return NotFound();
+        return Ok(MapToSpoolmanResponse(spool));
+    }
+
+    [HttpGet("spool")]
+    [ServiceFilter(typeof(SpoolmanAuthFilter))]
+    public async Task<IActionResult> ListSpools()
+    {
+        var spools = await _spools.GetAllByProjectAsync(ProjectId);
+        return Ok(spools.Select(MapToSpoolmanResponse).ToList());
+    }
+
+    [HttpPut("spool/{id:int}/use")]
+    [ServiceFilter(typeof(SpoolmanAuthFilter))]
+    public async Task<IActionResult> UseSpool(int id, [FromBody] SpoolmanUseRequest request)
+    {
+        var spool = await _spools.GetBySpoolmanIdAsync(id, ProjectId);
+        if (spool == null) return NotFound();
+
+        var material = spool.FilamentMaterial;
+        if (material == null) return StatusCode(500, new { message = "Filament material not found." });
+
+        decimal subtractGrams;
+
+        if (request.UseWeight.HasValue && request.UseWeight.Value > 0)
+        {
+            subtractGrams = request.UseWeight.Value;
+        }
+        else if (request.UseLength.HasValue && request.UseLength.Value > 0)
+        {
+            if (!material.DensityGCm3.HasValue || material.DensityGCm3.Value <= 0)
+                return BadRequest(new { message = "Filament density not configured. Cannot convert length to weight." });
+
+            var diameterMm = material.DiameterMm > 0 ? material.DiameterMm : 1.75m;
+            var radiusCm = (diameterMm / 2m) / 10m;
+            var lengthCm = request.UseLength.Value / 10m;
+            var volumeCm3 = (decimal)Math.PI * radiusCm * radiusCm * lengthCm;
+            subtractGrams = volumeCm3 * material.DensityGCm3.Value;
+        }
+        else
+        {
+            return BadRequest(new { message = "Either use_weight or use_length must be provided." });
+        }
+
+        var totalWeight = material.WeightGrams ?? 0;
+        await _spools.UpdateRemainingWeightAtomicAsync(spool.Id, subtractGrams, totalWeight);
+
+        var updated = await _spools.GetBySpoolmanIdAsync(id, ProjectId);
+        return Ok(MapToSpoolmanResponse(updated!));
+    }
+
+    private static SpoolmanSpoolResponse MapToSpoolmanResponse(Spool spool)
+    {
+        var material = spool.FilamentMaterial;
+        decimal totalWeight = material?.WeightGrams ?? 0;
+        var remaining = spool.RemainingWeightGrams;
+        var used = totalWeight - remaining;
+        if (used < 0) used = 0;
+
+        decimal remainingLength = 0;
+        decimal usedLength = 0;
+
+        if (material?.DensityGCm3 is > 0 && material.DiameterMm > 0)
+        {
+            var radiusCm = (material.DiameterMm / 2m) / 10m;
+            var crossSectionCm2 = (decimal)Math.PI * radiusCm * radiusCm;
+            var densityGPerCm3 = material.DensityGCm3.Value;
+
+            if (crossSectionCm2 > 0 && densityGPerCm3 > 0)
+            {
+                remainingLength = (remaining / (crossSectionCm2 * densityGPerCm3)) * 10m;
+                usedLength = (used / (crossSectionCm2 * densityGPerCm3)) * 10m;
+            }
+        }
+
+        var vendorName = material?.Brand ?? "Unknown";
+        var vendorId = vendorName.GetHashCode() & 0x7FFFFFFF;
+
+        return new SpoolmanSpoolResponse
+        {
+            Id = spool.SpoolmanId,
+            Registered = spool.CreatedAt.ToString("o"),
+            FirstUsed = spool.OpenedAt?.ToString("o"),
+            LastUsed = spool.UpdatedAt.ToString("o"),
+            Filament = new SpoolmanFilamentResponse
+            {
+                Id = spool.SpoolmanId,
+                Name = $"{material?.Brand ?? ""} {material?.Type ?? ""}".Trim(),
+                Material = material?.Type ?? "",
+                Vendor = new SpoolmanVendorResponse
+                {
+                    Id = vendorId,
+                    Name = vendorName,
+                },
+                ColorHex = material?.ColorHex ?? "000000",
+                Diameter = material?.DiameterMm ?? 1.75m,
+                Density = material?.DensityGCm3 ?? 0,
+                Weight = totalWeight,
+                SpoolWeight = 0,
+                SettingsExtruderTemp = material?.MaxTempCelsius ?? 0,
+                SettingsBedTemp = material?.BedTempCelsius ?? 0,
+            },
+            RemainingWeight = remaining,
+            UsedWeight = used,
+            RemainingLength = Math.Round(remainingLength, 1),
+            UsedLength = Math.Round(usedLength, 1),
+            Archived = spool.ConsumedAt != null,
+            Extra = new Dictionary<string, string>
+            {
+                ["spoolhero_id"] = spool.Id.ToString(),
+            },
+        };
+    }
+}

--- a/src/SpoolManager.Server/Controllers/SpoolmanSettingsController.cs
+++ b/src/SpoolManager.Server/Controllers/SpoolmanSettingsController.cs
@@ -1,0 +1,78 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SpoolManager.Infrastructure.Repositories;
+using SpoolManager.Server.Filters;
+using SpoolManager.Shared.DTOs.Spoolman;
+using SpoolManager.Shared.Models;
+
+namespace SpoolManager.Server.Controllers;
+
+[ApiController]
+[Route("api/spoolman/apikeys")]
+[Authorize]
+[ServiceFilter(typeof(ProjectAuthFilter))]
+public class SpoolmanSettingsController : ControllerBase
+{
+    private readonly ISpoolmanApiKeyRepository _apiKeys;
+
+    public SpoolmanSettingsController(ISpoolmanApiKeyRepository apiKeys)
+    {
+        _apiKeys = apiKeys;
+    }
+
+    private ProjectMember ProjectMember => (ProjectMember)HttpContext.Items["ProjectMember"]!;
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var keys = await _apiKeys.GetAllByProjectAsync(ProjectMember.ProjectId);
+        return Ok(keys.Select(k => new SpoolmanApiKeyDto
+        {
+            Id = k.Id,
+            ApiKey = k.ApiKey,
+            Name = k.Name,
+            CreatedAt = k.CreatedAt,
+            LastUsedAt = k.LastUsedAt,
+        }).ToList());
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateSpoolmanApiKeyRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            return BadRequest(new { message = "Name is required." });
+
+        var key = new SpoolmanApiKey
+        {
+            ProjectId = ProjectMember.ProjectId,
+            ApiKey = GenerateApiKey(),
+            Name = request.Name.Trim(),
+        };
+
+        await _apiKeys.CreateAsync(key);
+
+        return Ok(new SpoolmanApiKeyDto
+        {
+            Id = key.Id,
+            ApiKey = key.ApiKey,
+            Name = key.Name,
+            CreatedAt = key.CreatedAt,
+        });
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        await _apiKeys.DeleteAsync(id);
+        return NoContent();
+    }
+
+    private static string GenerateApiKey()
+    {
+        var bytes = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(bytes);
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/src/SpoolManager.Server/Controllers/SpoolsController.cs
+++ b/src/SpoolManager.Server/Controllers/SpoolsController.cs
@@ -192,6 +192,7 @@ public class SpoolsController : ControllerBase
     private static SpoolDto MapToDto(Spool s) => new()
     {
         Id = s.Id,
+        SpoolmanId = s.SpoolmanId,
         ProjectId = s.ProjectId,
         FilamentMaterialId = s.FilamentMaterialId,
         MaterialType = s.FilamentMaterial?.Type ?? string.Empty,

--- a/src/SpoolManager.Server/Controllers/TagsController.cs
+++ b/src/SpoolManager.Server/Controllers/TagsController.cs
@@ -43,7 +43,7 @@ public class TagsController : ControllerBase
             var spool = await _spools.GetByIdAsync(request.SpoolId.Value, ProjectMember.ProjectId);
             if (spool?.FilamentMaterial == null) return NotFound();
 
-            var ndefBytes = _openSpool.Encode(spool.FilamentMaterial, spool.Id);
+            var ndefBytes = _openSpool.Encode(spool.FilamentMaterial, spool.Id, spool.SpoolmanId);
             var json = _openSpool.ToJson(spool.FilamentMaterial, spool.Id);
             return Ok(new TagEncodeResponse { Base64 = Convert.ToBase64String(ndefBytes), JsonPayload = json });
         }
@@ -138,7 +138,7 @@ public class TagsController : ControllerBase
         var spool = await _spools.GetByIdAsync(spoolId, ProjectMember.ProjectId);
         if (spool?.FilamentMaterial == null) return NotFound();
 
-        var bytes = _openSpool.Encode(spool.FilamentMaterial, spool.Id);
+        var bytes = _openSpool.Encode(spool.FilamentMaterial, spool.Id, spool.SpoolmanId);
         var filename = $"openspool_{spool.FilamentMaterial.Brand}_{spool.FilamentMaterial.Type}_{spoolId}.bin".Replace(" ", "_");
         return File(bytes, "application/octet-stream", filename);
     }

--- a/src/SpoolManager.Server/Filters/SpoolmanAuthFilter.cs
+++ b/src/SpoolManager.Server/Filters/SpoolmanAuthFilter.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using SpoolManager.Infrastructure.Repositories;
+
+namespace SpoolManager.Server.Filters;
+
+public class SpoolmanAuthFilter : IAsyncActionFilter
+{
+    private readonly ISpoolmanApiKeyRepository _apiKeys;
+
+    public SpoolmanAuthFilter(ISpoolmanApiKeyRepository apiKeys) => _apiKeys = apiKeys;
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        string? apiKey = null;
+
+        if (context.HttpContext.Request.Headers.TryGetValue("X-Api-Key", out var headerValue))
+            apiKey = headerValue.ToString();
+
+        if (string.IsNullOrEmpty(apiKey) && context.HttpContext.Request.Query.TryGetValue("apikey", out var queryValue))
+            apiKey = queryValue.ToString();
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            context.Result = new UnauthorizedObjectResult(new { message = "X-Api-Key header or apikey query parameter is required." });
+            return;
+        }
+
+        var key = await _apiKeys.GetByApiKeyAsync(apiKey);
+        if (key == null)
+        {
+            context.Result = new UnauthorizedObjectResult(new { message = "Invalid API key." });
+            return;
+        }
+
+        context.HttpContext.Items["SpoolmanProjectId"] = key.ProjectId;
+
+        _ = Task.Run(async () =>
+        {
+            try { await _apiKeys.UpdateLastUsedAsync(key.Id); } catch { }
+        });
+
+        await next();
+    }
+}

--- a/src/SpoolManager.Server/Program.cs
+++ b/src/SpoolManager.Server/Program.cs
@@ -47,7 +47,9 @@ builder.Services.AddScoped<ISiteSettingsRepository, SiteSettingsRepository>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 builder.Services.AddHostedService<NotificationBackgroundService>();
 
+builder.Services.AddScoped<ISpoolmanApiKeyRepository, SpoolmanApiKeyRepository>();
 builder.Services.AddScoped<ProjectAuthFilter>();
+builder.Services.AddScoped<SpoolmanAuthFilter>();
 builder.Services.AddSingleton<LoginRateLimiter>();
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/SpoolManager.Shared/DTOs/Spoolman/SpoolmanDtos.cs
+++ b/src/SpoolManager.Shared/DTOs/Spoolman/SpoolmanDtos.cs
@@ -1,0 +1,128 @@
+using System.Text.Json.Serialization;
+
+namespace SpoolManager.Shared.DTOs.Spoolman;
+
+public class SpoolmanSpoolResponse
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("registered")]
+    public string Registered { get; set; } = string.Empty;
+
+    [JsonPropertyName("first_used")]
+    public string? FirstUsed { get; set; }
+
+    [JsonPropertyName("last_used")]
+    public string? LastUsed { get; set; }
+
+    [JsonPropertyName("filament")]
+    public SpoolmanFilamentResponse Filament { get; set; } = new();
+
+    [JsonPropertyName("remaining_weight")]
+    public decimal RemainingWeight { get; set; }
+
+    [JsonPropertyName("used_weight")]
+    public decimal UsedWeight { get; set; }
+
+    [JsonPropertyName("remaining_length")]
+    public decimal RemainingLength { get; set; }
+
+    [JsonPropertyName("used_length")]
+    public decimal UsedLength { get; set; }
+
+    [JsonPropertyName("archived")]
+    public bool Archived { get; set; }
+
+    [JsonPropertyName("extra")]
+    public Dictionary<string, string> Extra { get; set; } = new();
+}
+
+public class SpoolmanFilamentResponse
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("material")]
+    public string Material { get; set; } = string.Empty;
+
+    [JsonPropertyName("vendor")]
+    public SpoolmanVendorResponse Vendor { get; set; } = new();
+
+    [JsonPropertyName("color_hex")]
+    public string ColorHex { get; set; } = string.Empty;
+
+    [JsonPropertyName("diameter")]
+    public decimal Diameter { get; set; }
+
+    [JsonPropertyName("density")]
+    public decimal Density { get; set; }
+
+    [JsonPropertyName("weight")]
+    public decimal Weight { get; set; }
+
+    [JsonPropertyName("spool_weight")]
+    public decimal SpoolWeight { get; set; }
+
+    [JsonPropertyName("settings_extruder_temp")]
+    public int SettingsExtruderTemp { get; set; }
+
+    [JsonPropertyName("settings_bed_temp")]
+    public int SettingsBedTemp { get; set; }
+}
+
+public class SpoolmanVendorResponse
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}
+
+public class SpoolmanUseRequest
+{
+    [JsonPropertyName("use_weight")]
+    public decimal? UseWeight { get; set; }
+
+    [JsonPropertyName("use_length")]
+    public decimal? UseLength { get; set; }
+}
+
+public class SpoolmanHealthResponse
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = "healthy";
+}
+
+public class SpoolmanInfoResponse
+{
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "1.0.0";
+
+    [JsonPropertyName("automatic_backups")]
+    public bool AutomaticBackups { get; set; }
+
+    [JsonPropertyName("data_dir")]
+    public string DataDir { get; set; } = string.Empty;
+
+    [JsonPropertyName("logs_dir")]
+    public string LogsDir { get; set; } = string.Empty;
+}
+
+public class SpoolmanApiKeyDto
+{
+    public Guid Id { get; set; }
+    public string ApiKey { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
+}
+
+public class CreateSpoolmanApiKeyRequest
+{
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/SpoolManager.Shared/DTOs/Spools/SpoolDtos.cs
+++ b/src/SpoolManager.Shared/DTOs/Spools/SpoolDtos.cs
@@ -3,6 +3,7 @@ namespace SpoolManager.Shared.DTOs.Spools;
 public class SpoolDto
 {
     public Guid Id { get; set; }
+    public int SpoolmanId { get; set; }
     public Guid ProjectId { get; set; }
     public Guid FilamentMaterialId { get; set; }
     public string MaterialType { get; set; } = string.Empty;

--- a/src/SpoolManager.Shared/Models/Spool.cs
+++ b/src/SpoolManager.Shared/Models/Spool.cs
@@ -3,6 +3,7 @@ namespace SpoolManager.Shared.Models;
 public class Spool
 {
     public Guid Id { get; set; }
+    public int SpoolmanId { get; set; }
     public Guid ProjectId { get; set; }
     public Guid FilamentMaterialId { get; set; }
     public FilamentMaterial? FilamentMaterial { get; set; }

--- a/src/SpoolManager.Shared/Models/SpoolmanApiKey.cs
+++ b/src/SpoolManager.Shared/Models/SpoolmanApiKey.cs
@@ -1,0 +1,11 @@
+namespace SpoolManager.Shared.Models;
+
+public class SpoolmanApiKey
+{
+    public Guid Id { get; set; }
+    public Guid ProjectId { get; set; }
+    public string ApiKey { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
+}


### PR DESCRIPTION
Adds a Spoolman-compatible REST API so Moonraker can track filament usage directly against SpoolHero.

Changes:
- DB migration: spoolman_id column on spools, spoolman_api_keys table
- API endpoints: GET /api/v1/health, /info, /spool, /spool/{id}, PUT /spool/{id}/use
- API key auth for multi-tenant access (no JWT in Moonraker)
- NFC tags: second NDEF record with SPOOL:{id} for nfc2klipper compatibility
- Client: API key management page, SpoolmanId display on spool detail
- Staging workflow for beta branch